### PR TITLE
Fix error on README.md example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ jobs:
     - name: "Create devlopment environments namespace"
       uses: okteto/create-namespace@master
       with:
-        name: devenvs-cindylopez
+        namespace: devenvs-cindylopez
 ```
 


### PR DESCRIPTION
On README.md example usage, okteto/create-namespace@master is been passed a variable called name as input but the action.yml defines it as namespace